### PR TITLE
ci: skip-go-installation option has been removed from golangci action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,3 @@ jobs:
           go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        with:
-          skip-go-installation: true


### PR DESCRIPTION
See 
https://github.com/golangci/golangci-lint-action/blob/fe19838e9e0ffa7eae178e20d30baba60002bab1/README.md

> v4.0.0+ requires an explicit actions/setup-go installation step before using this action: uses: actions/setup-go@v5. The skip-go-installation option has been removed.
