### PR TITLE
Github Actions failing due to misconfigured linters file 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,12 @@
+version: "2"
 linters:
   enable:
     - thelper
-    - gofumpt
     - tparallel
     - unconvert
     - unparam
     - wastedassign
+formatters:
+  enable:
+    - gofumpt
+


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Github Actions for the template are failing due to a misconfiguration in the linters file and missing versioning. Creating this pull request to address it.

Example failed Github Actions upon creation of Repository from the provided template:
- https://github.com/gvyronos/tui/actions/runs/23988235671

Updated linter with new configuration:
- https://github.com/gvyronos/tui/actions/runs/23988688270

Thanks.